### PR TITLE
Update apiary.apib

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -330,6 +330,8 @@ You can add multiple query params. For **dates and numbers** you can use greater
 This filter will only list *active* meters where *last month value is before March 2015*.
 
 **NOTE!** Query params that are not recognized will be *silently ignored*, so make sure you spell them correctly!
+**NOTE!** We suggest using the `box` attribute to list the meters that are activated by customers. So you can use  `...meters?box=active...` instead of  `... meters?active=true ...`. 
+
 
 
 ### List meters [GET]


### PR DESCRIPTION
This PR updates documentation to prevent our customers to use `active` field while listing the activated meters. 